### PR TITLE
Fixed bug where the portal node drops an item players should never have

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -333,6 +333,7 @@ minetest.register_node('luckyportal:rift', {
 		minetest.sound_play("luckyportal_thunder", {pos = target_coords, gain = 7, max_hear_distance = 60,})
 		flash2(pos)
 	end,
+	drop = "luckyportal:luckyportal"
 	})
 
 


### PR DESCRIPTION
When falling nodes, et cetera break the portal node, it drops the version of the portal that doesn't set itself up properly when placed. This tiny patch fixes that.